### PR TITLE
Problem: unknown if it works in WASI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasi]
+runner = "wasmtime"

--- a/.cargo/config.wasmer.toml
+++ b/.cargo/config.wasmer.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasi]
+runner = "wasmer"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,9 +70,29 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Check if it builds
+
+      - name: Use wasmtime 0.23.0
+        uses: mwilliamson/setup-wasmtime-action@v1
+        with:
+          wasmtime-version: "0.23.0"
+
+      - name: Install wasmer
+        run: |-
+          curl https://get.wasmer.io -sSfL | sh
+
+      - name: Check if it builds and runs in Chrome
         run: |-
           wasm-pack test --chrome --headless
+
+      - name: Check if it builds and runs under wasmtime
+        run: |-
+          cargo test --target wasm32-wasi
+
+      - name: Check if it builds and runs under wasmer
+        run: |-
+          source ~/.wasmer/wasmer.sh
+          cp .cargo/config.wasmer.toml .cargo/config.toml
+          cargo test --target wasm32-wasi 
 
   lints:
     name: Lints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Support for `wasm32-wasi` target
+
 ## [0.1.0] - 2021-02-05
 
 Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ console-warn = []
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2"
+
+[package.metadata.wasm.rs]
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
+wasm-readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Chat](https://img.shields.io/discord/807386653852565545.svg?logo=discord)](https://discord.gg/qbcbjHWjaD)
 
 This micro-crate provides a drop-in replacement for [`std::dbg`](https://doc.rust-lang.org/std/macro.dbg.html) macro
-that logs to `console` when compiled for `wasm32` and falls back to `std::dbg` on all other platforms.
+that logs to `console` when compiled for `wasm32-unknown-unknown` and falls back to `std::dbg` on all other platforms.
 
 ## Usage
 

--- a/example/.cargo/config.toml
+++ b/example/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasi]
+runner = "wasmtime"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "wasm-rs-dbg-example-test"
+path = "src/main.rs"
+
 [dependencies]
 wasm-bindgen = "0.2.70"
 wasm-rs-dbg = { path = "..", default-features = false, features = ["console-warn"] }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,7 +1,8 @@
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen::prelude::*;
 use wasm_rs_dbg::dbg;
 
-#[wasm_bindgen(start)]
+#[cfg_attr(target_os = "unknown", wasm_bindgen(start))]
 pub fn example() {
     dbg!();
     dbg!("This is a test", Some(1));

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,0 +1,4 @@
+use wasm_rs_dbg_example::example;
+fn main() {
+    example();
+}

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,4 @@
+[toolchain]
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
+components = ["rustfmt", "clippy"]
+channel = "stable"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+  rustChannel = (pkgs.rustChannelOf { channel = "stable";  });
+  rust = (rustChannel.rust.override {
+    targets = ["wasm32-unknown-unknown" "wasm32-wasi"];
+  });
+in
+pkgs.stdenv.mkDerivation rec {
+  name = "wasm-rs-async-channel-shell";
+
+  buildInputs = with pkgs; [ rust nodejs
+                             openssl.dev pkgconfig # for cargo-release
+  ];
+
+  shellHook = ''
+    # Useful for ensuring cargo tools are available (like cargo-do, for example)
+    export PATH=$PATH:$HOME/.cargo/bin
+  '';
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,27 +12,45 @@
 //! // ...
 //! ```
 //!
-#[cfg(all(target_arch = "wasm32", feature = "console-debug"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "console-debug"
+))]
 pub use web_sys::console::debug_1 as log;
-#[cfg(all(target_arch = "wasm32", feature = "console-error"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "console-error"
+))]
 pub use web_sys::console::error_1 as log;
-#[cfg(all(target_arch = "wasm32", feature = "console-info"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "console-info"
+))]
 pub use web_sys::console::info_1 as log;
-#[cfg(all(target_arch = "wasm32", feature = "console-log"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "console-log"))]
 pub use web_sys::console::log_1 as log;
-#[cfg(all(target_arch = "wasm32", feature = "console-trace"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "console-trace"
+))]
 pub use web_sys::console::trace_1 as log;
-#[cfg(all(target_arch = "wasm32", feature = "console-warn"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "console-warn"
+))]
 pub use web_sys::console::warn_1 as log;
 
 /// This `dbg!` macro is a drop-in replacement for [`std::dbg`]
 ///
-/// It will use [`web_sys::console`] on `wasm32` architecture. On all
-/// other architectures it will call [`std::dbg`].
-///
-/// It will log at `debug` level by default, and this can configured
-/// with this crate's feature flags. For example, specifying `features = ["console-log"]`
-/// will send output at `log` level instead. Supported flags are:
+/// It will use [`web_sys::console`] on `wasm32-unknown-unknown`. On all
+/// other architectures it will call [`std::dbg`]. It will log at `debug` level by default, and
+/// this can configured with this crate's feature flags. For example, specifying `features =
+/// ["console-log"]` will send output at `log` level instead. Supported flags are:
 ///
 /// * `console-debug` (default)
 /// * `console-log`
@@ -47,15 +65,15 @@ pub use web_sys::console::warn_1 as log;
 #[macro_export]
 macro_rules! dbg {
     () => {{
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(target_os = "wasi", not(target_arch = "wasm32")))]
         std::dbg!();
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         $crate::log(&format!("[{}:{}]", std::file!(), std::line!()).into());
     }};
     ($val: expr $(,)?) => {{
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(target_os = "wasi", not(target_arch = "wasm32")))]
         std::dbg!($val);
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         // Use of `match` here is intentional because it affects the lifetimes
         // of temporaries - https://stackoverflow.com/a/48732525/1063961
         match $val {


### PR DESCRIPTION
Solution: enable WASI support

Turns out, it didn't work correctly in WASI as it expected `web-sys`
to work anywhere on `wasm32` target architecture.

With this change, wasm-rs-dbg will fallback to `std::dbg` on WASI.